### PR TITLE
Don't check for anonymous user access at index time.

### DIFF
--- a/src/Plugin/search_api/processor/HOCRField.php
+++ b/src/Plugin/search_api/processor/HOCRField.php
@@ -3,7 +3,6 @@
 namespace Drupal\islandora_hocr\Plugin\search_api\processor;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\file\FileInterface;
 use Drupal\islandora_hocr\Plugin\search_api\processor\Property\HOCRFieldProperty;
 use Drupal\media\Plugin\media\Source\File;
@@ -152,15 +151,10 @@ class HOCRField extends ProcessorPluginBase {
 
     $media = $query->execute();
 
-    $anonymous = new AnonymousUserSession();
-
     foreach ($media as $medium) {
       /** @var \Drupal\media\MediaInterface $entity */
       $entity = $media_storage->load($medium);
       if (!$entity) {
-        continue;
-      }
-      elseif (!$entity->access('view', $anonymous, FALSE)) {
         continue;
       }
 
@@ -170,10 +164,6 @@ class HOCRField extends ProcessorPluginBase {
         $fid = $source->getSourceFieldValue($entity);
         /** @var \Drupal\file\FileInterface $file */
         $file = $this->entityTypeManager->getStorage('file')->load($fid);
-
-        if (!$file->access('view', $anonymous, FALSE)) {
-          continue;
-        }
 
         return $file;
       }


### PR DESCRIPTION
Just removing the condition where the indexer bails if a media is not accessible to Anonymous. We have implemented passing auth headers to Mirador, see this Draft PR:  https://github.com/Islandora/islandora_mirador/pull/32