### PR TITLE
DGI9-614: Default snippets to 20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ drush migrate:import islandora_hocr_media_uses
 ```
 
 ## Configuration
+Configuration is presented performed via environment variables.
+
+| Variable                                 | Default                | Description                                                                                                                                        |
+|------------------------------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ISLANDORA_HOCR_SNIPPETS`                | `20`                   | Number of snippets per document to include in the response.                                                                                        |
 
 
 ### Derivatives

--- a/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
+++ b/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
@@ -147,10 +147,9 @@ EOXML;
       // Deal with absolute image coordinates.
       ->addParam('hl.ocr.absoluteHighlights', 'on')
       // We expect OCR per page.
-      ->addParam('hl.ocr.trackPages', 'off');
-    foreach (array_keys($highlight_fields) as $field) {
-      $handler->addParam("f.$field.hl.snippets", getenv('ISLANDORA_HOCR_SNIPPETS') ?: '20');
-    }
+      ->addParam('hl.ocr.trackPages', 'off')
+      // Set the default number of snippets.
+      ->addParam('hl.snippets', getenv('ISLANDORA_HOCR_SNIPPETS') ?: '20');
   }
 
   /**

--- a/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
+++ b/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
@@ -37,7 +37,7 @@ class HighlightingSolrConfigEventSubscriber implements EventSubscriberInterface 
    */
   public function __construct(
     string $library_path,
-    FieldsHelperInterface $fields_helper
+    FieldsHelperInterface $fields_helper,
   ) {
     $this->libraryPath = $library_path;
     $this->fieldsHelper = $fields_helper;

--- a/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
+++ b/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
@@ -141,7 +141,7 @@ EOXML;
     unset($info);
     $sapi_query->setOption('islandora_hocr_properties', $highlight_props);
     $sapi_query->setOption('islandora_hocr_fields', $highlight_fields);
-    $handler = $s_query->setHandler('select_ocr')
+    $s_query->setHandler('select_ocr')
       ->addParam('hl', 'true')
       ->addParam('hl.ocr.fl', implode(',', array_keys($highlight_fields)))
       // Deal with absolute image coordinates.

--- a/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
+++ b/src/EventSubscriber/HighlightingSolrConfigEventSubscriber.php
@@ -141,14 +141,16 @@ EOXML;
     unset($info);
     $sapi_query->setOption('islandora_hocr_properties', $highlight_props);
     $sapi_query->setOption('islandora_hocr_fields', $highlight_fields);
-
-    $s_query->setHandler('select_ocr')
+    $handler = $s_query->setHandler('select_ocr')
       ->addParam('hl', 'true')
       ->addParam('hl.ocr.fl', implode(',', array_keys($highlight_fields)))
       // Deal with absolute image coordinates.
       ->addParam('hl.ocr.absoluteHighlights', 'on')
       // We expect OCR per page.
       ->addParam('hl.ocr.trackPages', 'off');
+    foreach (array_keys($highlight_fields) as $field) {
+      $handler->addParam("f.$field.hl.snippets", getenv('ISLANDORA_HOCR_SNIPPETS') ?: '20');
+    }
   }
 
   /**

--- a/src/Plugin/search_api/processor/HOCRField.php
+++ b/src/Plugin/search_api/processor/HOCRField.php
@@ -56,7 +56,7 @@ class HOCRField extends ProcessorPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(DatasourceInterface|null $datasource = NULL) {
     if (!$datasource || $datasource->getEntityTypeId() != 'node') {
       return [];
     }

--- a/src/Plugin/search_api/processor/HOCRField.php
+++ b/src/Plugin/search_api/processor/HOCRField.php
@@ -56,7 +56,7 @@ class HOCRField extends ProcessorPluginBase {
   /**
    * {@inheritDoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface|null $datasource = NULL) {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
     if (!$datasource || $datasource->getEntityTypeId() != 'node') {
       return [];
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to document environment variable configuration, including a new variable for controlling the number of OCR snippets per document.

- **New Features**
  - Added support for configuring the number of OCR highlight snippets per field using an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->